### PR TITLE
Fix issue with 2GP package uploads for packages with API version older than 52.0

### DIFF
--- a/cumulusci/tasks/create_package_version.py
+++ b/cumulusci/tasks/create_package_version.py
@@ -151,6 +151,7 @@ class CreatePackageVersion(BaseSalesforceApiTask):
             "Defaults to False."
         },
     }
+    api_version = "52.0"
 
     def _init_options(self, kwargs):
         super()._init_options(kwargs)
@@ -199,7 +200,7 @@ class CreatePackageVersion(BaseSalesforceApiTask):
         self.tooling = get_simple_salesforce_connection(
             self.project_config,
             get_devhub_config(self.project_config),
-            api_version=self.project_config.project__package__api_version,
+            api_version=self.api_version,
             base_url="tooling",
         )
         self.context = TaskContext(self.org_config, self.project_config, self.logger)


### PR DESCRIPTION
Fixes the following error when creating a 2gp package version of a package with API version less than 52.0...

```
No such column 'IsOrgDependent' on entity 'Package2'. If you are attempting to use a 
custom field, be sure to append the '__c' after the custom field name. Please 
reference your WSDL or the describe call for the appropriate names.
```