### PR TITLE
Never set <fullName> in 2gp package generation manifests

### DIFF
--- a/cumulusci/tasks/create_package_version.py
+++ b/cumulusci/tasks/create_package_version.py
@@ -230,8 +230,7 @@ class CreatePackageVersion(BaseSalesforceApiTask):
         with convert_sfdx_source(
             self.project_config.default_package_path,
             None
-            if self.package_config.package_type == PackageTypeEnum.unlocked
-            else self.package_config.package_name,
+            None,
             self.logger,
         ) as path:
             package_zip_builder = MetadataPackageZipBuilder(


### PR DESCRIPTION
Change pulled from https://github.com/SFDO-Tooling/CumulusCI/pull/3748

Fixes https://github.com/SFDO-Tooling/CumulusCI/issues/3415 temporarily until that fix is merged