### PR TITLE
fix: added comma, removed additional None param

### DIFF
--- a/cumulusci/tasks/create_package_version.py
+++ b/cumulusci/tasks/create_package_version.py
@@ -229,7 +229,6 @@ class CreatePackageVersion(BaseSalesforceApiTask):
         package_zip_builder = None
         with convert_sfdx_source(
             self.project_config.default_package_path,
-            None
             None,
             self.logger,
         ) as path:


### PR DESCRIPTION
Underlying change pulled from [SFDO-Tooling#3748](https://github.com/SFDO-Tooling/CumulusCI/pull/3748)

Added missing comma and removed extra parameter.