### PR TITLE
Add new cci command group for hashing config, flows, and dependencies and support for freezing flows

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -20,6 +20,7 @@ from cumulusci.utils.logging import tee_stdout_stderr
 
 from .error import error
 from .flow import flow
+from .hash import hash_group
 from .logger import get_tempfile_logger, init_logger
 from .org import org
 from .plan import plan
@@ -242,3 +243,4 @@ cli.add_command(task)
 cli.add_command(flow)
 cli.add_command(plan)
 cli.add_command(robot)
+cli.add_command(hash_group)

--- a/cumulusci/cli/hash.py
+++ b/cumulusci/cli/hash.py
@@ -1,0 +1,104 @@
+import click
+import hashlib
+import json
+import os
+from cumulusci.core.dependencies.resolvers import get_static_dependencies
+from cumulusci.core.utils import process_list_arg
+from cumulusci.core.github import set_github_output
+from cumulusci.utils.hashing import hash_dict
+from pydantic import BaseModel
+from .runtime import pass_runtime
+
+
+@click.group(
+    "hash",
+    help="Commands for hashing parts of the project's CumulusCI configuration and state",
+)
+def hash_group():
+    pass
+
+
+# Commands for group: hash
+
+
+@hash_group.command(
+    name="config",
+    help="Hashes all or part of the project's merged CumulusCI configuration",
+)
+@pass_runtime(require_project=True, require_keychain=False)  # maybe not needed...
+@click.option(
+    "--locators",
+    "locators",
+    help="A comma separated list of CumulusCI config locators to specify the top level of config key(s) to hash. Example: project__package,flows__ci_beta",
+)
+def hash_config(
+    runtime,
+    locators,
+):
+    locators_str = "for {}".format(locators) if locators else ""
+    locators = process_list_arg(locators)
+    config = runtime.project_config.config
+    if locators:
+        config = {loc: runtime.project_config.lookup(loc) for loc in locators}
+    config_hash = hash_dict(config)
+    click.echo(f"Hash of CumulusCI Config{locators_str}:")
+    click.echo(config_hash)
+    output_name = "HASH_CONFIG"
+    if locators:
+        output_name + "__" + "__AND__".join(locators)
+    set_github_output(output_name, config_hash)
+
+
+@hash_group.command(
+    name="flow",
+    help="Hashes a flow's configuration, either dynamic or frozen as a flat list of static steps",
+)
+@pass_runtime(require_project=True, require_keychain=False)  # maybe not needed...
+@click.argument("flow_name")
+@click.option(
+    "--freeze",
+    is_flag=True,
+    help="Freeze the flow configuration as a flat list of static steps",
+)
+def hash_flow(
+    runtime,
+    flow_name,
+    freeze,
+):
+    flow = runtime.get_flow(flow_name)
+
+    steps = flow.steps
+    if freeze:
+        steps = flow.freeze(org_config=None)
+    config_hash = hash_dict(steps)
+    click.echo(f"Hash of flow {flow_name}:")
+    click.echo(config_hash)
+    output_name = "HASH_FLOW__" + flow_name
+    if freeze:
+        output_name + "__FROZEN"
+    set_github_output(output_name, config_hash)
+
+
+@hash_group.command(
+    name="dependencies",
+    help="Resolve and hash the project's current dependencies",
+)
+@click.option(
+    "--resolution-strategy",
+    help="The resolution strategy to use. Defaults to production.",
+    default="production",
+)
+@pass_runtime(require_keychain=True)
+def hash_dependencies(runtime, resolution_strategy):
+    resolved = get_static_dependencies(
+        runtime.project_config,
+        resolution_strategy=resolution_strategy,
+    )
+    dependencies = []
+    for dependency in resolved:
+        click.echo(dependency)
+        dependencies.append(dependency.dict())
+
+    deps_hash = hash_dict(dependencies)
+    click.echo(f"Hash of CumulusCI Dependencies for {resolution_strategy}:")
+    click.echo(deps_hash)

--- a/cumulusci/core/github.py
+++ b/cumulusci/core/github.py
@@ -603,7 +603,7 @@ def catch_common_github_auth_errors(func: Callable) -> Callable:
     def inner(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except (ConnectionError) as exc:
+        except ConnectionError as exc:
             if error_msg := format_github3_exception(exc):
                 raise GithubApiError(error_msg) from exc
             else:
@@ -663,3 +663,13 @@ def create_gist(github, description, files):
     files - A dict of files in the form of {filename:{'content': content},...}
     """
     return github.create_gist(description, files, public=False)
+
+
+# Utils for GitHub Actions worker environments
+def set_github_output(name: str, value: str):
+    """Set an output parameter for the GitHub Actions runner."""
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        return
+    with open(github_output, "a") as f:
+        f.write(f"{name}={value}\n")

--- a/cumulusci/utils/hashing.py
+++ b/cumulusci/utils/hashing.py
@@ -1,0 +1,31 @@
+import hashlib
+import json
+from pydantic import BaseModel
+
+
+def cci_json_encoder(obj):
+    if isinstance(obj, BaseModel):
+        return obj.dict()
+    if hasattr(obj, "task_config"):
+        if obj.skip:
+            return None
+        return obj.task_config
+    # Fallback to default encoder
+    try:
+        return json.JSONEncoder().default(obj)
+    except TypeError:
+        raise TypeError(
+            f"Object of type {obj.__class__.__name__} is not JSON serializable"
+        )
+
+
+def hash_dict(dictionary):
+    # Step 1: Serialize the dictionary in a sorted order to ensure consistency
+    serialized_dict = json.dumps(
+        dictionary, sort_keys=True, default=cci_json_encoder
+    ).encode("utf-8")
+
+    # Step 2: Create an MD5 hash of the serialized dictionary
+    md5_hash = hashlib.md5(serialized_dict).hexdigest()
+
+    return md5_hash[:8]


### PR DESCRIPTION
- New `cci hash` command group 
    - `cci hash config`: Hashes full project config 
    - `cci hash config --locators project__package,orgs__scratch__feature`: Hashes only two sections of config 
    - `cci hash flow dev_org`: Hashes the current dynamic configuration of the `dev_org` flow 
    - `cci hash flow dev_org --freeze`: Freezes the `dev_org` flow to a flattened list of static steps
    - `cci hash dependencies`: Resolves and hashes the current `production` dependencies for the project
    - `cci hash dependencies --resolution-strategy prerelease`: Resolve and hashes the current `prerelease` dependencies for the project
- New `cci flow freeze dev_org`: Freezes the flow, hashes the frozen flow, outputs dev_org__a1b2c3D4.yml with the frozen flow defiinition
- New `cumulusci.core.github.set_github_output` for handling setting a GitHub Actions output variable if running in a GitHub Actions worker
- Added `freeze` method to flowrunner